### PR TITLE
Feature: Create navigation host screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/project/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/App.kt
@@ -1,49 +1,49 @@
 package org.example.project
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import org.jetbrains.compose.ui.tooling.preview.Preview
-
-import valora.composeapp.generated.resources.Res
-import valora.composeapp.generated.resources.compose_multiplatform
+import org.example.project.core.navigation.BottomTab
+import org.example.project.features.explore.presentation.ExploreScreen
+import org.example.project.features.home.presentation.HomeScreen
+import org.example.project.features.settings.presentation.SettingsScreen
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
+        var selectedTab by rememberSaveable { mutableStateOf(BottomTab.Home) }
+
+        Scaffold(
+            bottomBar = {
+                NavigationBar {
+                    BottomTab.entries.forEach { tab ->
+                        NavigationBarItem(
+                            selected = selectedTab == tab,
+                            onClick = { selectedTab = tab },
+                            icon = { Text(tab.iconEmoji) },
+                            label = { Text(tab.label) }
+                        )
+                    }
                 }
             }
+        ) { innerPadding ->
+            AppContent(selectedTab, innerPadding)
         }
+    }
+}
+
+@Composable
+private fun AppContent(tab: BottomTab, innerPadding: PaddingValues) {
+    when (tab) {
+        BottomTab.Home -> HomeScreen.Content(innerPadding)
+        BottomTab.Explore -> ExploreScreen.Content(innerPadding)
+        BottomTab.Settings -> SettingsScreen.Content(innerPadding)
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/example/project/core/navigation/BottomTab.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/core/navigation/BottomTab.kt
@@ -1,0 +1,7 @@
+package org.example.project.core.navigation
+
+enum class BottomTab(val label: String, val iconEmoji: String) {
+    Home("Início", "🏠"),
+    Explore("Explorar", "🔎"),
+    Settings("Config", "⚙️")
+}

--- a/composeApp/src/commonMain/kotlin/org/example/project/features/explore/presentation/ExploreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/features/explore/presentation/ExploreScreen.kt
@@ -1,0 +1,29 @@
+package org.example.project.features.explore.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+object ExploreScreen {
+    @Composable
+    fun Content(innerPadding: PaddingValues) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .safeContentPadding(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("Explorar", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(top = 24.dp))
+            Text("Resultados e descoberta aqui.")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/example/project/features/home/presentation/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/features/home/presentation/HomeScreen.kt
@@ -1,0 +1,51 @@
+package org.example.project.features.home.presentation
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import valora.composeapp.generated.resources.Res
+import valora.composeapp.generated.resources.compose_multiplatform
+import org.example.project.Greeting
+
+object HomeScreen {
+    @Composable
+    fun Content(innerPadding: PaddingValues) {
+        val greeting = remember { Greeting().greet() }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .safeContentPadding()
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("Bem-vindo", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(top = 24.dp))
+            Image(painterResource(Res.drawable.compose_multiplatform), null)
+            Text("Compose: $greeting")
+            var showMore by remember { mutableStateOf(false) }
+            Button(onClick = { showMore = !showMore }, modifier = Modifier.padding(top = 16.dp)) {
+                Text(if (showMore) "Ocultar" else "Mostrar")
+            }
+            AnimatedVisibility(showMore) {
+                Text("Conteúdo adicional da Home")
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/example/project/features/settings/presentation/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/features/settings/presentation/SettingsScreen.kt
@@ -1,0 +1,29 @@
+package org.example.project.features.settings.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+object SettingsScreen {
+    @Composable
+    fun Content(innerPadding: PaddingValues) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .safeContentPadding(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("Configurações", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(top = 24.dp))
+            Text("Preferências do aplicativo.")
+        }
+    }
+}


### PR DESCRIPTION
- Refactored to single-activity Compose with a Material 3 bottom navigation (Scaffold + NavigationBar) and updated App.kt accordingly.
- Split screens into separate composable classes: HomeScreen, ExploreScreen, SettingsScreen under features/*/presentation.
- Moved BottomTab enum to core/navigation/BottomTab.kt
